### PR TITLE
chore: update references to policy-builder repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Enterprise Contract Policy Builder",
   "homepage": "https://enterprisecontract.dev/policy_builder/",
   "bugs": {
-    "url": "https://github.com/enterprise-contract/policy_builder/issues"
+    "url": "https://github.com/conforma/policy-builder/issues"
   },
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
This commit updates references to the policy-builder repository from `enterprise-contract/policy_builder` to `conforma/policy-builder`.

Ref: EC-1117